### PR TITLE
Fix for logout handler to prevent slew of errors

### DIFF
--- a/app/ios/SmartSyncExplorerReactNative/AppDelegate.m
+++ b/app/ios/SmartSyncExplorerReactNative/AppDelegate.m
@@ -165,32 +165,34 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
 
 - (void)handleSdkManagerLogout
 {
-    [self log:SFLogLevelDebug msg:@"SFAuthenticationManager logged out.  Resetting app."];
-    [self resetViewState:^{
-        [self initializeAppViewState];
-        
-        // Multi-user pattern:
-        // - If there are two or more existing accounts after logout, let the user choose the account
-        //   to switch to.
-        // - If there is one existing account, automatically switch to that account.
-        // - If there are no further authenticated accounts, present the login screen.
-        //
-        // Alternatively, you could just go straight to re-initializing your app state, if you know
-        // your app does not support multiple accounts.  The logic below will work either way.
-        NSArray *allAccounts = [SFUserAccountManager sharedInstance].allUserAccounts;
-        if ([allAccounts count] > 1) {
-            SFDefaultUserManagementViewController *userSwitchVc = [[SFDefaultUserManagementViewController alloc] initWithCompletionBlock:^(SFUserManagementAction action) {
-                [self.window.rootViewController dismissViewControllerAnimated:YES completion:NULL];
-            }];
-            [self.window.rootViewController presentViewController:userSwitchVc animated:YES completion:NULL];
-        } else {
-            if ([allAccounts count] == 1) {
-                [SFUserAccountManager sharedInstance].currentUser = ([SFUserAccountManager sharedInstance].allUserAccounts)[0];
-            }
-            
-            [[SalesforceSDKManager sharedManager] launch];
-        }
-    }];
+    dispatch_async(dispatch_get_main_queue(), ^{
+       [self log:SFLogLevelDebug msg:@"SFAuthenticationManager logged out.  Resetting app."];
+       [self resetViewState:^{
+           [self initializeAppViewState];
+           
+           // Multi-user pattern:
+           // - If there are two or more existing accounts after logout, let the user choose the account
+           //   to switch to.
+           // - If there is one existing account, automatically switch to that account.
+           // - If there are no further authenticated accounts, present the login screen.
+           //
+           // Alternatively, you could just go straight to re-initializing your app state, if you know
+           // your app does not support multiple accounts.  The logic below will work either way.
+           NSArray *allAccounts = [SFUserAccountManager sharedInstance].allUserAccounts;
+           if ([allAccounts count] > 1) {
+               SFDefaultUserManagementViewController *userSwitchVc = [[SFDefaultUserManagementViewController alloc] initWithCompletionBlock:^(SFUserManagementAction action) {
+                   [self.window.rootViewController dismissViewControllerAnimated:YES completion:NULL];
+               }];
+               [self.window.rootViewController presentViewController:userSwitchVc animated:YES completion:NULL];
+           } else {
+               if ([allAccounts count] == 1) {
+                   [SFUserAccountManager sharedInstance].currentUser = ([SFUserAccountManager sharedInstance].allUserAccounts)[0];
+               }
+               
+               [[SalesforceSDKManager sharedManager] launch];
+           }
+       }];
+    });
 }
 
 - (void)handleUserSwitch:(SFUserAccount *)fromUser


### PR DESCRIPTION
I was getting a slew of errors/warnings in the console.log on a logout.  This fixes that.
