### PR TITLE
Fix the issues to set up sample app on Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SmartSyncExplorer application written using React Native
 ``` shell
 ./install.sh (Windows users, please use "cscript install.vbs" instead of ./install.sh)
 cd app/<platform>
-npm start
+npm run-script start (Windows users please use "npm run-script start-windows" instead of npm run-script start)
 ```
 
 ## To run the application on iOS

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node_modules/react-native/packager/packager.sh --root js"
+    "start": "node_modules/react-native/packager/packager.sh --root js",
+    "start-windows": "node_modules\\react-native\\packager\\packager.sh --root js"
   },
   "dependencies": {
     "react": "15.2.0",

--- a/install.vbs
+++ b/install.vbs
@@ -48,7 +48,7 @@ End If
 'The following line is the equivalent of "cd .."
 objShell.CurrentDirectory = strWorkingDirectory
 WScript.Echo vbCrLf & "Getting js files"
-intReturnVal = objShell.Run("copy external\shared\libs\react.* app\js\", 1, True)
+intReturnVal = objShell.Run("xcopy external\shared\libs\react.* app\js\", 1, True)
 If intReturnVal <> 0 Then
     WScript.Echo "Error in copying js files!"
     WScript.Quit 3


### PR DESCRIPTION
Fix the issue that fail to copy react native js files and the issue that cannot start react native packager on Windows.
